### PR TITLE
feat: Add basic layout for "New Question", "Search Results" and "Profile Page"

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.4",
     "jest": "^29.3.1",
+    "mui-chips-input": "^1.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.7.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,24 @@
 import { Route, Routes } from "react-router-dom";
 import "./App.css";
+import Navbar from "./components/navbar";
 import Home from "./pages/HomePage";
 import NewQuestion from "./pages/NewQuestionPage";
 import NotFound from "./pages/NotFoundPage";
+import Profile from "./pages/ProfilePage";
 import SearchResult from "./pages/SearchResultPage";
 
 function App() {
   return (
-    <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="/searchResult" element={<SearchResult />} />
-      <Route path="/newQuestion" element={<NewQuestion />} />
-      <Route path="*" element={<NotFound />} />
-    </Routes>
+    <>
+      <Navbar />
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/searchResult" element={<SearchResult />} />
+        <Route path="/newQuestion" element={<NewQuestion />} />
+        <Route path="/profile" element={<Profile />} />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Route, Routes } from "react-router-dom";
 import "./App.css";
 import Home from "./pages/HomePage";
+import NewQuestion from "./pages/NewQuestionPage";
 import NotFound from "./pages/NotFoundPage";
 import SearchResult from "./pages/SearchResultPage";
 
@@ -9,6 +10,7 @@ function App() {
     <Routes>
       <Route path="/" element={<Home />} />
       <Route path="/searchResult" element={<SearchResult />} />
+      <Route path="/newQuestion" element={<NewQuestion />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -4,6 +4,7 @@ import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
+import GitHubIcon from '@mui/icons-material/GitHub';
 import MenuIcon from '@mui/icons-material/Menu';
 
 function Navbar() {
@@ -23,6 +24,17 @@ function Navbar() {
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
             Mathmate
           </Typography>
+          <IconButton
+            size="large"
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            sx={{ mr: 2 }}
+            onClick={()=>{ window.open('https://github.com/Mathmate-il', '_blank', 'noreferrer');}}
+          
+          >
+            <GitHubIcon />
+          </IconButton>
           <Button color="inherit" variant="outlined">Sign In</Button>
         </Toolbar>
       </AppBar>

--- a/src/components/searchInput.tsx
+++ b/src/components/searchInput.tsx
@@ -1,0 +1,21 @@
+import { Paper, InputBase, IconButton } from "@mui/material";
+import SearchIcon from '@mui/icons-material/Search';
+
+function SearchInput() {
+  return (
+    <Paper
+      component="form"
+      sx={{ p: "2px 4px", display: "flex", alignItems: "center", width: 400 }}
+    >
+      <InputBase
+        sx={{ ml: 1, flex: 1 }}
+        placeholder=""
+      />
+      <IconButton type="button" sx={{ p: "10px" }} aria-label="search">
+        <SearchIcon />
+      </IconButton>
+    </Paper>
+  );
+}
+
+export default SearchInput;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -11,7 +11,6 @@ function Home() {
 
   return (
     <div>
-      <Navbar />
       <h1>{newQuestion}</h1>
       <h2>{isLoggedIn.toString()}</h2>
       <div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -14,6 +14,17 @@ function Home() {
       <Navbar />
       <h1>{newQuestion}</h1>
       <h2>{isLoggedIn.toString()}</h2>
+      <div>
+        <Button
+          sx={{ mb: 2 }}
+          variant="contained"
+          onClick={() => {
+            navigate("/newQuestion");
+          }}
+        >
+          Ask your mate a math question
+        </Button>
+      </div>
       <Button
         variant="contained"
         onClick={() => {

--- a/src/pages/NewQuestionPage.tsx
+++ b/src/pages/NewQuestionPage.tsx
@@ -1,0 +1,55 @@
+import { TextField, Button, Chip } from "@mui/material";
+import { MuiChipsInput, MuiChipsInputChip } from "mui-chips-input";
+import { FormEvent, useState } from "react";
+
+function NewQuestion() {
+  const [title, setTitle] = useState("");
+  const [tags, setTags] = useState<MuiChipsInputChip[]>([]);
+  const [text, setText] = useState("");
+
+  const handleChange = (newTags: MuiChipsInputChip[]) => {
+    setTags(newTags);
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    // send a POST request to the server with the form data
+    // or, handle the form submission locally
+  };
+
+  return (
+    <>
+      <h1>New Question</h1>
+      <form onSubmit={handleSubmit}>
+        <TextField
+          label="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          fullWidth
+          required
+          sx={{ mb: 2 }}
+        />
+        <MuiChipsInput
+          value={tags}
+          onChange={handleChange}
+          fullWidth
+          sx={{ mb: 2 }}
+        />
+        <TextField
+          label="Text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          fullWidth
+          multiline
+          required
+          sx={{ mb: 2 }}
+        />
+        <Button type="submit" variant="contained" color="primary">
+          Ask
+        </Button>
+      </form>
+    </>
+  );
+}
+
+export default NewQuestion;

--- a/src/pages/NewQuestionPage.tsx
+++ b/src/pages/NewQuestionPage.tsx
@@ -4,7 +4,7 @@ import { FormEvent, useState } from "react";
 
 function NewQuestion() {
   const [title, setTitle] = useState("");
-  const [tags, setTags] = useState<MuiChipsInputChip[]>([]);
+  const [tags, setTags] = useState<MuiChipsInputChip[]>(["aaaaa","bbbbbb"]);
   const [text, setText] = useState("");
 
   const handleChange = (newTags: MuiChipsInputChip[]) => {
@@ -30,6 +30,7 @@ function NewQuestion() {
           sx={{ mb: 2 }}
         />
         <MuiChipsInput
+        disabled
           value={tags}
           onChange={handleChange}
           fullWidth

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,11 +1,29 @@
+import { Stack, Avatar, Button } from "@mui/material";
+import SettingsIcon from "@mui/icons-material/Settings";
+import LogoutIcon from "@mui/icons-material/Logout";
 
 function Profile() {
   return (
-    <>
-
-    <div>ProfilePage</div>
-    </>
-  )
+    <Stack spacing={2}>
+      <Stack direction="row" spacing={2}>
+        <Stack spacing={2}>
+          <h3>Full Name</h3>
+          <h5>email@gmail.com</h5>
+        </Stack>
+        <Avatar
+          alt="Remy Sharp"
+          src="https://mui.com/static/images/avatar/1.jpg"
+          sx={{ width: 150, height: 150 }}
+        />
+      </Stack>
+      <Button variant="text" startIcon={<SettingsIcon />}>
+        Setings
+      </Button>
+      <Button variant="text" startIcon={<LogoutIcon />}>
+        Logout
+      </Button>
+    </Stack>
+  );
 }
 
-export default Profile
+export default Profile;

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,0 +1,11 @@
+
+function Profile() {
+  return (
+    <>
+
+    <div>ProfilePage</div>
+    </>
+  )
+}
+
+export default Profile

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -1,13 +1,55 @@
-import { useEffect } from "react";
+import {
+  Card,
+  Container,
+  Divider,
+  IconButton,
+  InputBase,
+  Paper,
+  Stack,
+} from "@mui/material";
 import Navbar from "../components/navbar";
-import { initialQuestionObject } from "../typescript";
+import { initialQuestionObject, Question } from "../typescript";
+import SearchInput from "../components/searchInput";
+
+const TEST_CONTENT = `Natus beatae eaque adipisci perspiciatis aliquam et enim sed et enim sed 
+aliquam et enim sed et enim sed jsfgku
+occaecati beatae eaque adipisc....`;
 
 function SearchResult() {
+  const questions: Question[] = [
+    {
+      ...initialQuestionObject,
+      title: "QUESTION TITLE 1",
+      question: TEST_CONTENT,
+    },
+    {
+      ...initialQuestionObject,
+      title: "QUESTION TITLE 2",
+      question: TEST_CONTENT,
+    },
+    {
+      ...initialQuestionObject,
+      title: "QUESTION TITLE 3",
+      question: TEST_CONTENT,
+    },
+  ];
 
   return (
     <>
       <Navbar />
-      <div>SearchResultPage</div>
+
+      <Container sx={{ my: 2, justifyContent: "flex-start" }}>
+        <SearchInput />
+      </Container>
+
+      <Stack spacing={2}>
+        {questions.map((question) => (
+          <Card>
+            <h3>{question.title}</h3>
+            <p>{question.question}</p>
+          </Card>
+        ))}
+      </Stack>
     </>
   );
 }

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -1,10 +1,6 @@
 import {
   Card,
   Container,
-  Divider,
-  IconButton,
-  InputBase,
-  Paper,
   Stack,
 } from "@mui/material";
 import Navbar from "../components/navbar";

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -10,30 +10,42 @@ import {
 import Navbar from "../components/navbar";
 import { initialQuestionObject, Question } from "../typescript";
 import SearchInput from "../components/searchInput";
+import { MuiChipsInputChip, MuiChipsInput } from "mui-chips-input";
+import { useState } from "react";
 
 const TEST_CONTENT = `Natus beatae eaque adipisci perspiciatis aliquam et enim sed et enim sed 
 aliquam et enim sed et enim sed jsfgku
 occaecati beatae eaque adipisc....`;
 
-function SearchResult() {
-  const questions: Question[] = [
-    {
-      ...initialQuestionObject,
-      title: "QUESTION TITLE 1",
-      question: TEST_CONTENT,
-    },
-    {
-      ...initialQuestionObject,
-      title: "QUESTION TITLE 2",
-      question: TEST_CONTENT,
-    },
-    {
-      ...initialQuestionObject,
-      title: "QUESTION TITLE 3",
-      question: TEST_CONTENT,
-    },
-  ];
+const questions: Question[] = [
+  {
+    ...initialQuestionObject,
+    title: "QUESTION TITLE 1",
+    question: TEST_CONTENT,
+  },
+  {
+    ...initialQuestionObject,
+    title: "QUESTION TITLE 2",
+    question: TEST_CONTENT,
+  },
+  {
+    ...initialQuestionObject,
+    title: "QUESTION TITLE 3",
+    question: TEST_CONTENT,
+  },
+];
 
+
+function SearchResult() {
+
+  const [tags, setTags] = useState<MuiChipsInputChip[]>(["aaaaa","bbbbbb"]);
+  const [text, setText] = useState("");
+
+  const handleChange = (newTags: MuiChipsInputChip[]) => {
+    setTags(newTags);
+  };
+
+ 
   return (
     <>
       <Navbar />
@@ -41,6 +53,13 @@ function SearchResult() {
       <Container sx={{ my: 2, justifyContent: "flex-start" }}>
         <SearchInput />
       </Container>
+
+      <MuiChipsInput
+          value={tags}
+          onChange={handleChange}
+          fullWidth
+          sx={{ mb: 2 }}
+        />
 
       <Stack spacing={2}>
         {questions.map((question) => (

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -42,8 +42,6 @@ function SearchResult() {
  
   return (
     <>
-      <Navbar />
-
       <Container sx={{ my: 2, justifyContent: "flex-start" }}>
         <SearchInput />
       </Container>

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -39,12 +39,10 @@ const questions: Question[] = [
 function SearchResult() {
 
   const [tags, setTags] = useState<MuiChipsInputChip[]>(["aaaaa","bbbbbb"]);
-  const [text, setText] = useState("");
 
   const handleChange = (newTags: MuiChipsInputChip[]) => {
     setTags(newTags);
   };
-
  
   return (
     <>


### PR DESCRIPTION
I used an external package called `mui-chips-input`  just to move forward quickly with the development
In the future, we might want to use our own `chips-component-input`.

No logic yet, only the basic layout was created.



![image](https://user-images.githubusercontent.com/7828909/214979245-a61e862c-7e87-4441-a7ef-aa4829db3834.png)
![image](https://user-images.githubusercontent.com/7828909/215096813-ee3be6f2-9d54-4389-90de-ca265312e5ac.png)
![image](https://user-images.githubusercontent.com/7828909/215106826-e5a0125b-ae3f-4a31-b6ef-5d7320237ada.png)

